### PR TITLE
jobs should now only be repainted if the jobs have changed(including last built time)

### DIFF
--- a/terminator/__main__.py
+++ b/terminator/__main__.py
@@ -11,6 +11,7 @@ def pause():
 
 def loop():
     jobs = []
+    previous_jobs = []
     refresh_counter = 0
 
     while True:
@@ -26,7 +27,9 @@ def loop():
         else:
             jobs = jenkins.refresh_jobs(jobs)
 
-        display.repaint(jobs)
+        if previous_jobs != jobs:
+            display.repaint(jobs)
+            previous_jobs = jobs
 
         refresh_counter += 1
 

--- a/terminator/job.py
+++ b/terminator/job.py
@@ -31,8 +31,8 @@ class Job:
     def _friendly_built_on(self):
         timestamp = math.floor(self.timestamp_millis / 1000)
 
-        if datetime.now().timestamp() - timestamp < 10:
-            return 'moments ago'
+        if datetime.now().timestamp() - timestamp < 60:
+            return 'less than a minute ago'
 
         date = datetime.fromtimestamp(timestamp)
 
@@ -43,4 +43,5 @@ class Job:
                 and self.timestamp_millis == other.timestamp_millis
                 and self.duration_millis == other.duration_millis
                 and self.is_successful == other.is_successful
-                and self.is_building == other.is_building)
+                and self.is_building == other.is_building
+                and self.built_on == other.built_on)


### PR DESCRIPTION
added in built_on into the "job" equals and changed "moments ago" to "less than a minute" in the _friendly_built_on function

terminator should now only re-render the jobs a maximum of once a minute if there has been no activity on any jobs.
